### PR TITLE
Use the Tag super interface for mp3 tags

### DIFF
--- a/src/io/qaralotte/ncmdump/Dump.java
+++ b/src/io/qaralotte/ncmdump/Dump.java
@@ -58,7 +58,7 @@ public class Dump {
         } else if (meta.format.equals("mp3")) {
             MP3FileReader mp3_reader = new MP3FileReader();
             audio_file = mp3_reader.read(output_music);
-            ID3v22Tag id3_tag = (ID3v22Tag) audio_file.getTag();
+            Tag id3_tag = audio_file.getTag();
             fix_tag(audio_file, meta, album_image, id3_tag);
         } else {
             throw new Exception("UNSUPPORT FORMAT!");


### PR DESCRIPTION
I have an ncm file results in such exception:

```
Exception in thread "main" java.lang.ClassCastException: org.jaudiotagger.tag.id3.ID3v24Tag cannot be cast to org.jaudiotagger.tag.id3.ID3v22Tag
        at io.qaralotte.ncmdump.Dump.execute(Dump.java:56)
        at io.qaralotte.ncmdump.Executor.main(Executor.java:16)
```

This commit would fix it.